### PR TITLE
Fix BoundedCache possible deadlock

### DIFF
--- a/api/bUtility.RemoteTokenCache/Properties/AssemblyInfo.cs
+++ b/api/bUtility.RemoteTokenCache/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.0.0.6")]
-[assembly: AssemblyFileVersion("0.0.0.6")]
+[assembly: AssemblyVersion("0.0.0.7")]
+[assembly: AssemblyFileVersion("0.0.0.7")]

--- a/api/bUtility.TokenCache.Common/from.framework/BoundedCache.cs
+++ b/api/bUtility.TokenCache.Common/from.framework/BoundedCache.cs
@@ -247,11 +247,9 @@ namespace bUtility.TokenCache
 
             // -1 milleseconds is infinite timeout
             _readWriteLock.AcquireWriterLock(TimeSpan.FromMilliseconds(-1));
-
-            EnforceQuota();
-
             try
             {
+                EnforceQuota();
                 if (_items.ContainsKey(key))
                 {
                     return false;


### PR DESCRIPTION
Fix BoundedCache TryAdd method by putting EnforceQuota inside the try statement in order to avoid deadlock.
+
Update bUtility.RemoteTokenCache version in order to include updated bUtility.TokenCache.Common.dll
